### PR TITLE
CloudFrontでタスクが終了しないエラーの対応

### DIFF
--- a/client/gulpfile.js/cfInvalidation.js
+++ b/client/gulpfile.js/cfInvalidation.js
@@ -1,38 +1,6 @@
-const {
-  src
-} = require("gulp")
-const awspublish = require("gulp-awspublish")
-const parallelize = require("concurrent-transform")
 const through = require('through2')
 const aws = require('aws-sdk')
 const log = require('fancy-log')
-
-const config = {
-  distDir: "dist",
-  concurrentUploads: 10,
-  headers: {
-    /* 'Cache-Control': 'max-age=315360000, no-transform, public', */
-  },
-}
-
-const awspublishConfig = {
-  params: {
-    Bucket: process.env.AWS_CLIENT_BUCKET_NAME
-  },
-  region: process.env.AWS_DEFAULT_REGION,
-  cacheFileName: ".awspublish",
-}
-
-const cfConfig = {
-  credentials: {
-    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-    signatureVersion: "v3"
-  },
-  distribution: process.env.AWS_CLOUDFRONT, // CloudFront distribution ID
-  indexRootPath: true,
-  wait: true, // CloudFront のキャッシュ削除が完了するまでの時間（約30〜60秒）
-}
 
 // CloudFront のキャッシュを削除する
 // https://github.com/lpender/gulp-cloudfront-invalidate-aws-publish/blob/master/index.js
@@ -126,17 +94,4 @@ const cfInvalidation = (options) => {
   return through.obj(processFile, invalidate);
 }
 
-const deploy = () => {
-  // S3 オプションを使用して新しい publisher を作成する
-  // http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property
-  const publisher = awspublish.create(awspublishConfig)
-
-  return src("./" + config.distDir + "/**")
-    .pipe(parallelize(publisher.publish(config.headers), config.concurrentUploads)) // S3にアップロードする
-    .pipe(cfInvalidation(cfConfig)) // CloudFrontのキャッシュを削除する
-    .pipe(publisher.sync()) // S3をdist以下のファイルに同期し、古いファイルを削除する
-    .pipe(publisher.cache()) // 連続したアップロードを高速化するためにキャッシュファイルを作成する
-    .pipe(awspublish.reporter()) // アップロードの更新をコンソールに出力する
-}
-
-exports.deploy = deploy
+exports.defalut = cfInvalidation

--- a/client/gulpfile.js/index.js
+++ b/client/gulpfile.js/index.js
@@ -1,0 +1,48 @@
+const {
+  src
+} = require("gulp")
+const awspublish = require("gulp-awspublish")
+const parallelize = require("concurrent-transform")
+const cfInvalidation = require("./cfInvalidation")
+
+const config = {
+  distDir: "dist",
+  concurrentUploads: 10,
+  headers: {
+    /* 'Cache-Control': 'max-age=315360000, no-transform, public', */
+  },
+}
+
+const awspublishConfig = {
+  params: {
+    Bucket: process.env.AWS_CLIENT_BUCKET_NAME
+  },
+  region: process.env.AWS_DEFAULT_REGION,
+  cacheFileName: ".awspublish",
+}
+
+const cfConfig = {
+  credentials: {
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    signatureVersion: "v3"
+  },
+  distribution: process.env.AWS_CLOUDFRONT, // CloudFront distribution ID
+}
+
+const deploy = (cb) => {
+  // S3 オプションを使用して新しい publisher を作成する
+  // http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property
+  const publisher = awspublish.create(awspublishConfig)
+
+  src("./" + config.distDir + "/**")
+    .pipe(parallelize(publisher.publish(config.headers), config.concurrentUploads)) // S3にアップロードする
+    .pipe(cfInvalidation(cfConfig)) // CloudFrontのキャッシュを削除する
+    .pipe(publisher.sync()) // S3をdist以下のファイルに同期し、古いファイルを削除する
+    .pipe(publisher.cache()) // 連続したアップロードを高速化するためにキャッシュファイルを作成する
+    .pipe(awspublish.reporter()) // アップロードの更新をコンソールに出力する
+
+  cb()
+}
+
+exports.deploy = deploy


### PR DESCRIPTION
負荷試験 #13 の変更に伴うgulp deployの修正。

* CloudFrontでタスクが終了しないエラーの対応
* ファイルを分割する

## エラー内容

```
[22:41:52] The following tasks did not complete: deploy
[22:41:52] Did you forget to signal async completion?
```