### PR TITLE
分割したファイルのexportエラーの修正

### DIFF
--- a/client/gulpfile.js/cfInvalidation.js
+++ b/client/gulpfile.js/cfInvalidation.js
@@ -94,4 +94,4 @@ const cfInvalidation = (options) => {
   return through.obj(processFile, invalidate);
 }
 
-exports.defalut = cfInvalidation
+exports.cfInvalidation = cfInvalidation

--- a/client/gulpfile.js/index.js
+++ b/client/gulpfile.js/index.js
@@ -3,7 +3,9 @@ const {
 } = require("gulp")
 const awspublish = require("gulp-awspublish")
 const parallelize = require("concurrent-transform")
-const cfInvalidation = require("./cfInvalidation")
+const {
+  cfInvalidation
+} = require("./cfInvalidation")
 
 const config = {
   distDir: "dist",
@@ -31,7 +33,7 @@ const cfConfig = {
 }
 
 const deploy = (cb) => {
-  // S3 オプションを使用して新しい publisher を作成する
+  // S3 オプションを使用して新しい p
   // http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property
   const publisher = awspublish.create(awspublishConfig)
 

--- a/client/gulpfile.js/index.js
+++ b/client/gulpfile.js/index.js
@@ -33,7 +33,7 @@ const cfConfig = {
 }
 
 const deploy = (cb) => {
-  // S3 オプションを使用して新しい p
+  // S3 オプションを使用して新しい publisher を作成する
   // http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property
   const publisher = awspublish.create(awspublishConfig)
 


### PR DESCRIPTION
負荷試験 #13 の変更に伴うgulp deployの修正。ファイル分割した関数を、関数として読み込まれるようにする。

## エラー内容

```
[23:05:13] 'deploy' errored after 17 ms
[23:05:13] TypeError: cfInvalidation is not a function
```