### PR TITLE
gulpfileのコードを一時的に以前の状態に戻す

### DIFF
--- a/client/gulpfile.js/index.js
+++ b/client/gulpfile.js/index.js
@@ -7,6 +7,8 @@ const {
   cfInvalidation
 } = require("./cfInvalidation")
 
+const cloudfront = require("gulp-cloudfront-invalidate-aws-publish")
+
 const config = {
   distDir: "dist",
   concurrentUploads: 10,
@@ -39,8 +41,10 @@ const deploy = (cb) => {
 
   src("./" + config.distDir + "/**")
     .pipe(parallelize(publisher.publish(config.headers), config.concurrentUploads)) // S3にアップロードする
-    .pipe(cfInvalidation(cfConfig)) // CloudFrontのキャッシュを削除する
-    .pipe(publisher.sync('')) // S3をdist以下のファイルに同期し、古いファイルを削除する
+    .pipe(cloudfront(cfConfig))
+    .pipe(publisher.sync()) // S3をdist以下のファイルに同期し、古いファイルを削除する
+    .pipe(publisher.cache()) // 連続したアップロードを高速化するためにキャッシュファイルを作成する
+    .pipe(awspublish.reporter()) // アップロードの更新をコンソールに出力する
 
   cb()
 }


### PR DESCRIPTION
負荷試験 #13 の、「S3の未使用ファイルを削除する」で、以前のコードでファイルが削除されるかを確認する。