### PR TITLE
Nginxのテスト用パスの作成、PHP-FPMのワーカー数の変更

### DIFF
--- a/docker/api/php-fpm/www.production.conf
+++ b/docker/api/php-fpm/www.production.conf
@@ -53,7 +53,7 @@ env[SENTRY_LARAVEL_DSN] = ${SENTRY_LARAVEL_DSN}
 listen.acl_users = apache,nginx
 
 pm = static
-pm.max_children = 10
+pm.max_children = 4
 ; pm.max_requests = 500
 
 php_value[session.save_handler] = files

--- a/docker/nginx/nginx.development.conf
+++ b/docker/nginx/nginx.development.conf
@@ -152,6 +152,12 @@ http {
         # インデックスファイルの指定
         index index.html index.htm index.php;
 
+        # TODO: テスト用に作成しているので後ほど削除
+        location /healthcheck {
+            default_type text/plan;
+            return 200 'Good Request';
+        }
+
         location / {
             try_files $uri $uri/ /index.php?$query_string;
         }

--- a/docker/nginx/nginx.production.conf
+++ b/docker/nginx/nginx.production.conf
@@ -155,6 +155,12 @@ http {
         # インデックスファイルの指定
         index index.html index.htm index.php;
 
+        # TODO: テスト用に作成しているので後ほど削除
+        location /healthcheck {
+            default_type text/plan;
+            return 200 'Good Request';
+        }
+
         location / {
             try_files $uri $uri/ /index.php?$query_string;
         }


### PR DESCRIPTION
負荷試験 #13 のパフォーマンスチューニング。

* Nginxから直接レスポンスを返すテスト用パスの作成
* PHP-FPMのワーカー数を4に設定する