### PR TITLE
PHP-FPMのワーカー数の調整

### DIFF
--- a/docker/api/php-fpm/www.development.conf
+++ b/docker/api/php-fpm/www.development.conf
@@ -17,9 +17,13 @@ request_terminate_timeout = 60s
 request_slowlog_timeout = 30s
 slowlog = /proc/self/fd/2
 
-pm = static
-pm.max_children = 2
+pm = dynamic
+pm.max_children = 10
+pm.start_servers = 2
+pm.min_spare_servers = 2
+pm.max_spare_servers = 5
 pm.max_requests = 500
+pm.process_idle_timeout = 10s
 
 ;;;;;;;;;;;;;;;;;;;;
 ; common settings ;

--- a/docker/api/php-fpm/www.production.conf
+++ b/docker/api/php-fpm/www.production.conf
@@ -48,7 +48,7 @@ env[NEWRELIC_LICENSE_KEY] = ${NEWRELIC_LICENSE_KEY}
 env[SENTRY_LARAVEL_DSN] = ${SENTRY_LARAVEL_DSN}
 
 pm = static
-pm.max_children = 4
+pm.max_children = 3
 pm.max_requests = 500
 
 ;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
負荷試験 #13 のパフォーマンス・チューニング。

最終的なPHP-FPMのワーカー数は下記に決定。

```
pm = static
pm.max_children = 3
```

※ECSのタスクサイズは 2 vCPU、4GB Memory