### PR TITLE
subscriptionsが登録されなかった時の対応

### DIFF
--- a/api/app/Http/Controllers/Api/SubscriptionWebhookController.php
+++ b/api/app/Http/Controllers/Api/SubscriptionWebhookController.php
@@ -30,7 +30,7 @@ class SubscriptionWebhookController extends ApiController
     /**
      * @var int
      */
-    const ADD_END_DAYS = 2;
+    private const ADD_END_DAYS = 2;
 
     /**
      * Webhookの処理

--- a/api/app/Http/Controllers/Api/SubscriptionWebhookController.php
+++ b/api/app/Http/Controllers/Api/SubscriptionWebhookController.php
@@ -6,7 +6,6 @@ use App\Models\Subscription;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
-use Log;
 
 /**
  * @group 5. Subscriptions
@@ -14,7 +13,7 @@ use Log;
 class SubscriptionWebhookController extends ApiController
 {
     /**
-     * @var \Stripe\Subscription
+     * @var \Stripe\Subscription|\Stripe\Invoice
      */
     private $stripeSubscription;
 
@@ -27,6 +26,11 @@ class SubscriptionWebhookController extends ApiController
      * @var Subscription
      */
     private $subscription;
+
+    /**
+     * @var int
+     */
+    const ADD_END_DAYS = 2;
 
     /**
      * Webhookの処理
@@ -52,17 +56,35 @@ class SubscriptionWebhookController extends ApiController
         }
 
         switch ($event->type) {
-            case 'customer.subscription.created':
+            case 'invoice.payment_succeeded': // 支払い成功時
                 $this->setEventData($event);
 
-                if (empty($this->user) || empty($this->subscription)) {
+                info($this->stripeSubscription->lines->data[0]);
+
+                if (empty($this->user)) {
                     return $this->respondWithOK([]);
                 }
 
-                $this->subscription->ends_at = null;
-                $this->subscription->save();
+                /** @phpstan-ignore-next-line */
+                $endsAt = Carbon::createFromTimestamp($this->stripeSubscription->lines->data[0]->period->end)->addDays(self::ADD_END_DAYS);
+
+                if (isset($this->subscription)) {
+                    $this->subscription->ends_at = $endsAt;
+                    $this->subscription->save();
+                    break;
+                }
+
+                $subscription = new Subscription();
+                $subscription->fill([
+                    'user_id' => $this->user->id,
+                    'name' => 'serverside',
+                    'stripe_id' => $this->stripeSubscription->subscription,
+                    'stripe_status' => $this->stripeSubscription->status,
+                    'ends_at' => $endsAt,
+                ]);
+                $subscription->save();
                 break;
-            case 'customer.subscription.deleted':
+            case 'customer.subscription.deleted': // サブスクリプション終了時
                 $this->setEventData($event);
 
                 if (empty($this->user) || empty($this->subscription)) {
@@ -72,7 +94,7 @@ class SubscriptionWebhookController extends ApiController
                 $this->subscription->ends_at = Carbon::createFromTimestamp($this->stripeSubscription->ended_at);
                 $this->subscription->save();
                 break;
-            case 'customer.subscription.updated':
+            case 'customer.subscription.updated': // サブスクリプション再開、キャンセル時
                 $this->setEventData($event);
 
                 if (empty($this->user) || empty($this->subscription)) {
@@ -82,7 +104,7 @@ class SubscriptionWebhookController extends ApiController
                 if ($this->stripeSubscription->cancel_at_period_end) { // サブスクリプションキャンセル時
                     $this->subscription->ends_at = Carbon::createFromTimestamp($this->stripeSubscription->cancel_at);
                 } else { // サブスクリプション再開時
-                    $this->subscription->ends_at = null;
+                    $this->subscription->ends_at = Carbon::createFromTimestamp($this->stripeSubscription->current_period_end)->addDays(self::ADD_END_DAYS);
                 }
 
                 $this->subscription->save();
@@ -102,13 +124,19 @@ class SubscriptionWebhookController extends ApiController
     {
         /** @phpstan-ignore-next-line */
         $this->stripeSubscription = $event->data->object;
-        Log::info($this->stripeSubscription); // Webhookで渡される実データが不明なので一時的にログに吐いておく
 
         $this->user = User::firstWhere('stripe_id', $this->stripeSubscription->customer);
         if (!$this->user) {
             return;
         }
 
-        $this->subscription = $this->user->subscriptions()->firstWhere('stripe_id', $this->stripeSubscription->items->data[0]->subscription);
+        $stripeSubscriptionId = '';
+        if ($this->stripeSubscription->items) { // invoice.payment_succeeded 以外のイベント時
+            $stripeSubscriptionId = $this->stripeSubscription->items->data[0]->subscription;
+        } elseif ($this->stripeSubscription->lines) { // invoice.payment_succeeded のイベント時
+            $stripeSubscriptionId = $this->stripeSubscription->lines->data[0]->subscription;
+        }
+
+        $this->subscription = $this->user->subscriptions()->firstWhere('stripe_id', $stripeSubscriptionId);
     }
 }


### PR DESCRIPTION
fixes https://github.com/dokugaku-engineer/dokugaku-engineer/issues/80

* stripeの課金が成功したのにsubscriptionモデルが保存されないことがある→Webhookで保存する
* 一度サブスクリプションが成功すると、その後失敗しても見続けることができる→subscriptions.ends_atに終了予定日+2日後のデータを入れる
* stripeの管理画面でwebhookにinvoice.payment_succeededを追加する