### PR TITLE
キャンセル済みのユーザーが支払履歴を確認できるようにする

### DIFF
--- a/client/components/partials/settings/CustomerPortalLink.vue
+++ b/client/components/partials/settings/CustomerPortalLink.vue
@@ -1,0 +1,43 @@
+<template>
+  <div>
+    <nuxt-link to='' class="confirm-link" @click.native="show">
+      お支払い履歴の確認はこちら
+    </nuxt-link>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.confirm-link {
+  font-size: $font-size-sm;
+}
+</style>
+
+<script>
+export default {
+  methods: {
+    async getOptions() {
+      const token = await this.$auth0.getTokenSilently()
+      return {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    },
+    async show(e) {
+      e.preventDefault()
+      const options = await this.getOptions()
+      this.$axios
+        .$get('/subscriptions/customer_portal', options)
+        .then((res) => {
+          window.location.assign(res.url)
+        })
+        .catch((error) => {
+          console.error('Error:', error)
+        })
+    },
+  },
+  head: {
+    script: [{ src: 'https://js.stripe.com/v3/' }],
+  },
+}
+</script>

--- a/client/components/partials/settings/CustomerPortalLink.vue
+++ b/client/components/partials/settings/CustomerPortalLink.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <nuxt-link to='' class="confirm-link" @click.native="show">
+    <nuxt-link to="" class="confirm-link" @click.native="show">
       お支払い履歴の確認はこちら
     </nuxt-link>
   </div>

--- a/client/pages/settings/billing/index.vue
+++ b/client/pages/settings/billing/index.vue
@@ -52,8 +52,8 @@
             </div>
             <subscribe-button />
             <div v-if="subscriptionStatus == 'canceled'" class="setting-link">
-                <customer-portal-link />
-              </div>
+              <customer-portal-link />
+            </div>
           </div>
         </div>
       </div>
@@ -209,7 +209,7 @@ export default {
         return true
       }
       return false
-    }
+    },
   },
 }
 </script>


### PR DESCRIPTION
fixes https://github.com/dokugaku-engineer/dokugaku-engineer/issues/77

サブスクリプションをキャンセルしたユーザーが過去の支払い履歴を見ることが出来なかったので、キャンセルしたユーザーに支払い履歴を確認できるようにした。