### PR TITLE
テスト時にDockerにログインしておらずテストが落ちるので、Dockerにログインする

### DIFF
--- a/client/testspec.yml
+++ b/client/testspec.yml
@@ -16,6 +16,8 @@ env:
     AWS_CLOUDFRONT: "/Prod/DokugakuEngineer/Client/AWS_CLOUDFRONT"
     AWS_DEFAULT_REGION: "/Prod/DokugakuEngineer/Client/AWS_DEFAULT_REGION"
     AWS_SECRET_ACCESS_KEY: "/Prod/DokugakuEngineer/Client/AWS_SECRET_ACCESS_KEY"
+    DOCKERHUB_USERNAME: "/Prod/DokugakuEngineer/Client/DOCKERHUB_USERNAME"
+    DOCKERHUB_PASSWORD: "/Prod/DokugakuEngineer/Client/DOCKERHUB_PASSWORD"
     ORIGIN: "/Prod/DokugakuEngineer/Client/ORIGIN"
     SENTRY_DSN: "/Prod/DokugakuEngineer/Client/SENTRY_DSN"
     GA_TRACKING_ID: "/Prod/DokugakuEngineer/Client/GA_TRACKING_ID"
@@ -26,6 +28,9 @@ phases:
       nodejs: 10
   build:
     commands:
+      - cd client
+      - echo Logging in to Docker...
+      - docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
       - echo 'Build docker image'
       - docker image build -t dokugaku_engineer_client:latest -f docker/client/Dockerfile . --build-arg env=testing
       - echo 'Start docker container'

--- a/client/testspec.yml
+++ b/client/testspec.yml
@@ -32,7 +32,7 @@ phases:
       - echo Logging in to Docker...
       - docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
       - echo 'Build docker image'
-      - docker image build -t dokugaku_engineer_client:latest -f docker/client/Dockerfile . --build-arg env=testing
+      - docker image build -t dokugaku_engineer_client:latest -f ../docker/client/Dockerfile . --build-arg env=testing
       - echo 'Start docker container'
       - docker container run --name dokugaku_engineer_client -d dokugaku_engineer_client:latest
   post_build:


### PR DESCRIPTION
fixes: https://github.com/dokugaku-engineer/dokugaku-engineer/issues/91

ClientのCIでのテスト時に「Dockerのプルの上限に達しました」エラーになるので、Dockerにログインすることでエラーを回避する。