### PR TITLE
 新規ユーザー登録時のユーザー名に対するアプリケーション側でのバリデーションが効いていない。 

### DIFF
--- a/api/app/Http/Requests/UserRequest.php
+++ b/api/app/Http/Requests/UserRequest.php
@@ -50,7 +50,7 @@ class UserRequest extends ApiRequest
     public function messages()
     {
         return [
-            'username.requiered' => 'ユーザー名は必須です',
+            'username.required' => 'ユーザー名は必須です',
             'username.min' => 'ユーザー名は3文字以上で入力してください',
             'username.max' => 'ユーザー名は50文字以内で入力してください',
             'username.unique' => 'ユーザー名はすでに登録されています',


### PR DESCRIPTION
## Bug
- 新規ユーザー登録時のユーザー名に対するアプリケーション側でのバリデーションが効いていない。
- 現状、HTMLのrequired属性やVueによるバリデーションがあるため問題ないように思えるが、なんらかの方法でフロントのバリデーションが突破された場合アプリケーション側で検知できない。（もしMySQLの厳密モードが有効でない空文字のユーザー名が登録されてしまうかも？）
## Fix
タイポを修正致しました。

## その他
突然のPR失礼致します。（こちらのPRは#104 のブランチ名が不適切だったため作成し直したものです 🙇 ）
いつもYoutubeの方拝見させていただいております。

偶然タイポを見つけましたので、もし問題なければマージしていただけますと嬉しいです！
（プロジェクトに設定したgitアカウントとPRに使用しているgitアカウントが違いますがどちらも私です。）

お忙しいところ恐縮ですが、ご査収のほど宜しくお願い致します。